### PR TITLE
Use first group schema type when there is only one group schema

### DIFF
--- a/Sources/SwagGenKit/SwiftFormatter.swift
+++ b/Sources/SwagGenKit/SwiftFormatter.swift
@@ -151,7 +151,12 @@ public class SwiftFormatter: CodeFormatter {
             }
         case let .reference(reference):
             return getSchemaTypeName(reference.component)
-        case .group:
+        case let .group(groupSchema):
+            if groupSchema.schemas.count == 1, let singleGroupSchema = groupSchema.schemas.first {
+                //flatten group schemas with only one schema
+                return getSchemaType(name: name, schema: singleGroupSchema)
+            }
+
             return escapeType(name.upperCamelCased())
         case .any:
             return "Any"


### PR DESCRIPTION
This avoids hitting the fallback to using the property name which without further intervention results in missing types when compiling generated code